### PR TITLE
feat: when providing a custom client, pass it all the way through

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl Jwks {
             .await?;
         let jwks_uri = oidc_config.jwks_uri;
 
-        Self::from_jwks_url_with_client(&reqwest::Client::default(), &jwks_uri).await
+        Self::from_jwks_url_with_client(client, &jwks_uri).await
     }
 
     /// # Arguments


### PR DESCRIPTION
Without this change, if you specify a custom client (say you need custom certs for example), the OIDC request will succeed but then the jwks request will fail.