### PR TITLE
Update jsonwebtoken and thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.22.1"
 jsonwebtoken = "10.2.0"
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.195", features = ["derive"] }
-thiserror = "1.0.56"
+thiserror = "2"
 tokio = { version = "1.35.1", features = ["full"] }
 
 [features]


### PR DESCRIPTION
This just updates the jsonwebtoken and thiserror dependencies to their latest versions (10.2.0 and 2.0.17 respectively, at time of writing). This will fix #24.

This also introduces two features for this crate, to match the new two features in jsonwebtoken. I didn't make either of them the default, to match the interface presented by jsonwebtoken. The library consumer must enable exactly one of them for jsonwebtoken to compile, though.